### PR TITLE
Update haxelib.json

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -16,7 +16,6 @@
     "version": "0.1.0",
     "url": "https://github.com/haxe-react/haxe-react-native-navigation",
     "dependencies": {
-      "react": "",
       "react-native": ""
     }
   }


### PR DESCRIPTION
That dependency is kind of problematic in the case we use react-next, since it force to install both libs and can lead to some kind of confusion.